### PR TITLE
feat: move unplugins to core

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,9 @@
     "unified": "^11.0.5",
     "unist-builder": "^4.0.0",
     "unist-util-visit": "^5.0.0",
-    "unplugin-fonts": "^1.3.1"
+    "unplugin-auto-import": "^19.1.0",
+    "unplugin-fonts": "^1.3.1",
+    "unplugin-icons": "^22.1.0"
   },
   "pnpm": {
     "patchedDependencies": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "vinxi": "^0.5.3",
     "vite": "^5.4.8"
   },
-  "packageManager": "pnpm@10.5.0+sha512.11106a5916c7406fe4b8cb8e3067974b8728f47308a4f5ac5e850304afa6f57e2847d7950dfe78877d8d36bfb401d381c4215db3a4c3547ffa63c14333a6fa51",
+  "packageManager": "pnpm@10.5.1+sha512.c424c076bd25c1a5b188c37bb1ca56cc1e136fbf530d98bcb3289982a08fd25527b8c9c4ec113be5e3393c39af04521dd647bcf1d0801eaf8ac6a7b14da313af",
   "dependencies": {
     "@docsearch/css": "^3.6.2",
     "@docsearch/js": "^3.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@solid-mediakit/og@0.3.1':
-    hash: 7satoney4oehcfj2r6hpo5kjyq
+    hash: 1dd90c51e34409638dd0bf880a19a308379221e6d3717ff4e251aa213e6e86cf
     path: patches/@solid-mediakit__og@0.3.1.patch
 
 importers:
@@ -214,7 +214,7 @@ importers:
         version: link:..
       '@solid-mediakit/og':
         specifier: ^0.3.1
-        version: 0.3.1(patch_hash=7satoney4oehcfj2r6hpo5kjyq)(@solidjs/meta@0.29.4(solid-js@1.9.5))(@solidjs/start@1.1.1(solid-js@1.9.5)(vinxi@0.5.3(@types/node@22.13.5)(db0@0.2.4)(ioredis@5.5.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))(vite@6.1.1(@types/node@22.13.5)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)))(rollup@4.34.8)(solid-js@1.9.5)
+        version: 0.3.1(patch_hash=1dd90c51e34409638dd0bf880a19a308379221e6d3717ff4e251aa213e6e86cf)(@solidjs/meta@0.29.4(solid-js@1.9.5))(@solidjs/start@1.1.1(solid-js@1.9.5)(vinxi@0.5.3(@types/node@22.13.5)(db0@0.2.4)(ioredis@5.5.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))(vite@6.1.1(@types/node@22.13.5)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)))(rollup@4.34.8)(solid-js@1.9.5)
       '@solidjs/router':
         specifier: ^0.15.3
         version: 0.15.3(solid-js@1.9.5)
@@ -5526,7 +5526,7 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@solid-mediakit/og@0.3.1(patch_hash=7satoney4oehcfj2r6hpo5kjyq)(@solidjs/meta@0.29.4(solid-js@1.9.5))(@solidjs/start@1.1.1(solid-js@1.9.5)(vinxi@0.5.3(@types/node@22.13.5)(db0@0.2.4)(ioredis@5.5.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))(vite@6.1.1(@types/node@22.13.5)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)))(rollup@4.34.8)(solid-js@1.9.5)':
+  '@solid-mediakit/og@0.3.1(patch_hash=1dd90c51e34409638dd0bf880a19a308379221e6d3717ff4e251aa213e6e86cf)(@solidjs/meta@0.29.4(solid-js@1.9.5))(@solidjs/start@1.1.1(solid-js@1.9.5)(vinxi@0.5.3(@types/node@22.13.5)(db0@0.2.4)(ioredis@5.5.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))(vite@6.1.1(@types/node@22.13.5)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)))(rollup@4.34.8)(solid-js@1.9.5)':
     dependencies:
       '@babel/core': 7.25.2
       '@solid-mediakit/shared': 0.0.6(rollup@4.34.8)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@solid-mediakit/og@0.3.1':
-    hash: 1dd90c51e34409638dd0bf880a19a308379221e6d3717ff4e251aa213e6e86cf
+    hash: 7satoney4oehcfj2r6hpo5kjyq
     path: patches/@solid-mediakit__og@0.3.1.patch
 
 importers:
@@ -37,6 +37,9 @@ importers:
       '@fontsource-variable/lexend':
         specifier: ^5.1.2
         version: 5.1.2
+      '@iconify-json/lucide':
+        specifier: ^1.2.26
+        version: 1.2.26
       '@kobalte/core':
         specifier: ^0.13.7
         version: 0.13.9(solid-js@1.9.5)
@@ -133,9 +136,15 @@ importers:
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.0.0
+      unplugin-auto-import:
+        specifier: ^19.1.0
+        version: 19.1.0
       unplugin-fonts:
         specifier: ^1.3.1
         version: 1.3.1(vite@6.1.1(@types/node@22.13.5)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0))
+      unplugin-icons:
+        specifier: ^22.1.0
+        version: 22.1.0
     devDependencies:
       '@biomejs/biome':
         specifier: ^1.9.4
@@ -208,7 +217,7 @@ importers:
         version: link:..
       '@solid-mediakit/og':
         specifier: ^0.3.1
-        version: 0.3.1(patch_hash=1dd90c51e34409638dd0bf880a19a308379221e6d3717ff4e251aa213e6e86cf)(@solidjs/meta@0.29.4(solid-js@1.9.5))(@solidjs/start@1.1.1(solid-js@1.9.5)(vinxi@0.5.3(@types/node@22.13.5)(db0@0.2.4)(ioredis@5.5.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))(vite@6.1.1(@types/node@22.13.5)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)))(rollup@4.34.8)(solid-js@1.9.5)
+        version: 0.3.1(patch_hash=7satoney4oehcfj2r6hpo5kjyq)(@solidjs/meta@0.29.4(solid-js@1.9.5))(@solidjs/start@1.1.1(solid-js@1.9.5)(vinxi@0.5.3(@types/node@22.13.5)(db0@0.2.4)(ioredis@5.5.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))(vite@6.1.1(@types/node@22.13.5)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)))(rollup@4.34.8)(solid-js@1.9.5)
       '@solidjs/router':
         specifier: ^0.15.3
         version: 0.15.3(solid-js@1.9.5)
@@ -316,6 +325,12 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@antfu/install-pkg@1.0.0':
+    resolution: {integrity: sha512-xvX6P/lo1B3ej0OsaErAjqgFYzYVcJpamjLAFLYh9vRJngBrMoUG7aVnrGTeqM7yxbyTD5p3F2+0/QUEh8Vzhw==}
+
+  '@antfu/utils@8.1.1':
+    resolution: {integrity: sha512-Mex9nXf9vR6AhcXmMrlz/HVgYYZpVGJ6YlPgwl7UnaFpnshXs6EK/oa5Gpf3CzENMjkvEx2tQtntGnb7UtSTOQ==}
 
   '@babel/code-frame@7.26.2':
     resolution: {integrity: sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==}
@@ -1120,6 +1135,15 @@ packages:
 
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
+
+  '@iconify-json/lucide@1.2.26':
+    resolution: {integrity: sha512-arD/8mK0lRxFY2LgLf345NhWVWiOtV8sOxJuLnq4QRz3frMiOwVwGxEgp5Xe/bRGzxO2CxxCBok0bPRpCkYZQQ==}
+
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@2.3.0':
+    resolution: {integrity: sha512-GmQ78prtwYW6EtzXRU1rY+KwOKfz32PD7iJh6Iyqw68GiKuoZ2A6pRtzWONz5VQJbp50mEjXh/7NkumtrAgRKA==}
 
   '@internationalized/date@3.7.0':
     resolution: {integrity: sha512-VJ5WS3fcVx0bejE/YHfbDKR/yawZgKqn/if+oEeLqNwBtPzVB06olkfcnojTmEMX+gTpH+FlQ69SHNitJ8/erQ==}
@@ -2521,6 +2545,10 @@ packages:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
 
+  globals@15.15.0:
+    resolution: {integrity: sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==}
+    engines: {node: '>=18'}
+
   globby@14.1.0:
     resolution: {integrity: sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==}
     engines: {node: '>=18'}
@@ -2846,6 +2874,9 @@ packages:
 
   knitwork@1.2.0:
     resolution: {integrity: sha512-xYSH7AvuQ6nXkq42x0v5S8/Iry+cfulBz/DJQzhIyESdLD7425jXsPy4vn5cCXU+HhRN2kVw51Vd1K6/By4BQg==}
+
+  kolorist@1.8.0:
+    resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
 
   lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
@@ -3264,6 +3295,9 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  package-manager-detector@0.2.9:
+    resolution: {integrity: sha512-+vYvA/Y31l8Zk8dwxHhL3JfTuHPm6tlxM2A3GeQyl7ovYnSp1+mzAxClxaOr0qO1TtPxbQxetI7v5XqKLJZk7Q==}
 
   pako@0.2.9:
     resolution: {integrity: sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==}
@@ -3761,6 +3795,9 @@ packages:
   strip-literal@2.1.1:
     resolution: {integrity: sha512-631UJ6O00eNGfMiWG78ck80dfBab8X6IVFB51jZK5Icd7XAs60Z5y7QdSd/wGIklnWvRbUNloVzhOKKmutxQ6Q==}
 
+  strip-literal@3.0.0:
+    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
+
   stubborn-fs@1.2.5:
     resolution: {integrity: sha512-H2N9c26eXjzL/S/K+i/RHHcFanE74dptvvjM8iwzwbVcWY/zjBbgRqF3K0DY4+OD+uTTASTBvDoxPDaPN02D7g==}
 
@@ -3934,6 +3971,10 @@ packages:
   unimport@3.14.6:
     resolution: {integrity: sha512-CYvbDaTT04Rh8bmD8jz3WPmHYZRG/NnvYVzwD6V1YAlvvKROlAeNDUBhkBGzNav2RKaeuXvlWYaa1V4Lfi/O0g==}
 
+  unimport@4.1.2:
+    resolution: {integrity: sha512-oVUL7PSlyVV3QRhsdcyYEMaDX8HJyS/CnUonEJTYA3//bWO+o/4gG8F7auGWWWkrrxBQBYOO8DKe+C53ktpRXw==}
+    engines: {node: '>=18.12.0'}
+
   unist-builder@4.0.0:
     resolution: {integrity: sha512-wmRFnH+BLpZnTKpc5L7O67Kac89s9HMrtELpnNaE6TAobq5DTZZs5YaTQfAZBA9bFPECx2uVAPO31c+GVug8mg==}
 
@@ -3971,6 +4012,18 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unplugin-auto-import@19.1.0:
+    resolution: {integrity: sha512-B+TGBEBHqY9aR+7YfShfLujETOHstzpV+yaqgy5PkfV0QG7Py+TYMX7vJ9W4SrysHR+UzR+gzcx/nuZjmPeclA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@nuxt/kit': ^3.2.2
+      '@vueuse/core': '*'
+    peerDependenciesMeta:
+      '@nuxt/kit':
+        optional: true
+      '@vueuse/core':
+        optional: true
+
   unplugin-fonts@1.3.1:
     resolution: {integrity: sha512-GmaJWPAWH6lBI4fP8xKdbMZJwTgsnr8PGJOfQE52jlod8QkqSO4M529Nox2L8zYapjB5hox2wCu4N3c/LOal/A==}
     peerDependencies:
@@ -3979,6 +4032,33 @@ packages:
     peerDependenciesMeta:
       '@nuxt/kit':
         optional: true
+
+  unplugin-icons@22.1.0:
+    resolution: {integrity: sha512-ect2ZNtk1Zgwb0NVHd0C1IDW/MV+Jk/xaq4t8o6rYdVS3+L660ZdD5kTSQZvsgdwCvquRw+/wYn75hsweRjoIA==}
+    peerDependencies:
+      '@svgr/core': '>=7.0.0'
+      '@svgx/core': ^1.0.1
+      '@vue/compiler-sfc': ^3.0.2 || ^2.7.0
+      svelte: ^3.0.0 || ^4.0.0 || ^5.0.0
+      vue-template-compiler: ^2.6.12
+      vue-template-es2015-compiler: ^1.9.0
+    peerDependenciesMeta:
+      '@svgr/core':
+        optional: true
+      '@svgx/core':
+        optional: true
+      '@vue/compiler-sfc':
+        optional: true
+      svelte:
+        optional: true
+      vue-template-compiler:
+        optional: true
+      vue-template-es2015-compiler:
+        optional: true
+
+  unplugin-utils@0.2.4:
+    resolution: {integrity: sha512-8U/MtpkPkkk3Atewj1+RcKIjb5WBimZ/WSLhhR3w6SsIj8XJuKTacSP8g+2JhfSGw0Cb125Y+2zA/IzJZDVbhA==}
+    engines: {node: '>=18.12.0'}
 
   unplugin@1.16.1:
     resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
@@ -4389,6 +4469,13 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.8
       '@jridgewell/trace-mapping': 0.3.25
+
+  '@antfu/install-pkg@1.0.0':
+    dependencies:
+      package-manager-detector: 0.2.9
+      tinyexec: 0.3.2
+
+  '@antfu/utils@8.1.1': {}
 
   '@babel/code-frame@7.26.2':
     dependencies:
@@ -4968,6 +5055,25 @@ snapshots:
 
   '@iarna/toml@2.2.5': {}
 
+  '@iconify-json/lucide@1.2.26':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@2.3.0':
+    dependencies:
+      '@antfu/install-pkg': 1.0.0
+      '@antfu/utils': 8.1.1
+      '@iconify/types': 2.0.0
+      debug: 4.4.0(supports-color@9.4.0)
+      globals: 15.15.0
+      kolorist: 1.8.0
+      local-pkg: 1.0.0
+      mlly: 1.7.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@internationalized/date@3.7.0':
     dependencies:
       '@swc/helpers': 0.5.15
@@ -5430,7 +5536,7 @@ snapshots:
 
   '@sindresorhus/merge-streams@2.3.0': {}
 
-  '@solid-mediakit/og@0.3.1(patch_hash=1dd90c51e34409638dd0bf880a19a308379221e6d3717ff4e251aa213e6e86cf)(@solidjs/meta@0.29.4(solid-js@1.9.5))(@solidjs/start@1.1.1(solid-js@1.9.5)(vinxi@0.5.3(@types/node@22.13.5)(db0@0.2.4)(ioredis@5.5.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))(vite@6.1.1(@types/node@22.13.5)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)))(rollup@4.34.8)(solid-js@1.9.5)':
+  '@solid-mediakit/og@0.3.1(patch_hash=7satoney4oehcfj2r6hpo5kjyq)(@solidjs/meta@0.29.4(solid-js@1.9.5))(@solidjs/start@1.1.1(solid-js@1.9.5)(vinxi@0.5.3(@types/node@22.13.5)(db0@0.2.4)(ioredis@5.5.0)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(typescript@5.7.3)(yaml@2.7.0))(vite@6.1.1(@types/node@22.13.5)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)))(rollup@4.34.8)(solid-js@1.9.5)':
     dependencies:
       '@babel/core': 7.25.2
       '@solid-mediakit/shared': 0.0.6(rollup@4.34.8)
@@ -6565,6 +6671,8 @@ snapshots:
 
   globals@11.12.0: {}
 
+  globals@15.15.0: {}
+
   globby@14.1.0:
     dependencies:
       '@sindresorhus/merge-streams': 2.3.0
@@ -6972,6 +7080,8 @@ snapshots:
   klona@2.0.6: {}
 
   knitwork@1.2.0: {}
+
+  kolorist@1.8.0: {}
 
   lazystream@1.0.1:
     dependencies:
@@ -7787,6 +7897,8 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
+  package-manager-detector@0.2.9: {}
+
   pako@0.2.9: {}
 
   parse-css-color@0.2.1:
@@ -8398,6 +8510,10 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
+  strip-literal@3.0.0:
+    dependencies:
+      js-tokens: 9.0.1
+
   stubborn-fs@1.2.5: {}
 
   style-to-object@1.0.8:
@@ -8619,6 +8735,23 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
+  unimport@4.1.2:
+    dependencies:
+      acorn: 8.14.0
+      escape-string-regexp: 5.0.0
+      estree-walker: 3.0.3
+      local-pkg: 1.0.0
+      magic-string: 0.30.17
+      mlly: 1.7.4
+      pathe: 2.0.3
+      picomatch: 4.0.2
+      pkg-types: 1.3.1
+      scule: 1.3.0
+      strip-literal: 3.0.0
+      tinyglobby: 0.2.12
+      unplugin: 2.2.0
+      unplugin-utils: 0.2.4
+
   unist-builder@4.0.0:
     dependencies:
       '@types/unist': 3.0.3
@@ -8667,11 +8800,35 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unplugin-auto-import@19.1.0:
+    dependencies:
+      local-pkg: 1.0.0
+      magic-string: 0.30.17
+      picomatch: 4.0.2
+      unimport: 4.1.2
+      unplugin: 2.2.0
+      unplugin-utils: 0.2.4
+
   unplugin-fonts@1.3.1(vite@6.1.1(@types/node@22.13.5)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)):
     dependencies:
       fast-glob: 3.3.3
       unplugin: 2.0.0-beta.1
       vite: 6.1.1(@types/node@22.13.5)(jiti@2.4.2)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.0)
+
+  unplugin-icons@22.1.0:
+    dependencies:
+      '@antfu/install-pkg': 1.0.0
+      '@iconify/utils': 2.3.0
+      debug: 4.4.0(supports-color@9.4.0)
+      local-pkg: 1.0.0
+      unplugin: 2.2.0
+    transitivePeerDependencies:
+      - supports-color
+
+  unplugin-utils@0.2.4:
+    dependencies:
+      pathe: 2.0.3
+      picomatch: 4.0.2
 
   unplugin@1.16.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,9 +37,6 @@ importers:
       '@fontsource-variable/lexend':
         specifier: ^5.1.2
         version: 5.1.2
-      '@iconify-json/lucide':
-        specifier: ^1.2.26
-        version: 1.2.26
       '@kobalte/core':
         specifier: ^0.13.7
         version: 0.13.9(solid-js@1.9.5)
@@ -1135,9 +1132,6 @@ packages:
 
   '@iarna/toml@2.2.5':
     resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
-
-  '@iconify-json/lucide@1.2.26':
-    resolution: {integrity: sha512-arD/8mK0lRxFY2LgLf345NhWVWiOtV8sOxJuLnq4QRz3frMiOwVwGxEgp5Xe/bRGzxO2CxxCBok0bPRpCkYZQQ==}
 
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
@@ -5054,10 +5048,6 @@ snapshots:
   '@fontsource/lexend@5.1.2': {}
 
   '@iarna/toml@2.2.5': {}
-
-  '@iconify-json/lucide@1.2.26':
-    dependencies:
-      '@iconify/types': 2.0.0
 
   '@iconify/types@2.0.0': {}
 

--- a/src/client/page-data.ts
+++ b/src/client/page-data.ts
@@ -44,8 +44,9 @@ const [CurrentPageDataProvider, useCurrentPageDataContext] =
 						// @ts-ignore
 						typeof window.$$SolidBase_page_data !== "undefined" &&
 						// @ts-ignore
-						typeof window.$$SolidBase_page_data[$component.src.split("?")[0]] !==
-							"undefined"
+						typeof window.$$SolidBase_page_data[
+							$component.src.split("?")[0]
+						] !== "undefined"
 					) {
 						const pageData = (window as Record<string, any>)
 							.$$SolidBase_page_data[$component.src.split("?")[0]];

--- a/src/client/page-data.ts
+++ b/src/client/page-data.ts
@@ -44,7 +44,7 @@ const [CurrentPageDataProvider, useCurrentPageDataContext] =
 						// @ts-ignore
 						typeof window.$$SolidBase_page_data !== "undefined" &&
 						// @ts-ignore
-						typeof window.$$SolidBase_page_data[component.src.split("?")[0]] !==
+						typeof window.$$SolidBase_page_data[$component.src.split("?")[0]] !==
 							"undefined"
 					) {
 						const pageData = (window as Record<string, any>)

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -33,7 +33,8 @@ export type SolidBaseConfig<ThemeConfig> = {
 	icons?: Omit<IconsOptions, "compiler"> | false;
 	// disabled by default
 	autoImport?:
-		| (AutoImportOptions & { iconResolver?: ComponentResolverOption | false }) | true;
+		| (AutoImportOptions & { iconResolver?: ComponentResolverOption | false })
+		| true;
 };
 
 type ResolvedConfigKeys =

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,7 +2,10 @@ import type {
 	SolidStartInlineConfig,
 	ViteCustomizableConfig,
 } from "@solidjs/start/config";
-import type { Plugin, PluginOption } from "vite";
+import type { Options as AutoImportOptions } from "unplugin-auto-import/dist/types.js";
+import type { Options as FontsOptions } from "unplugin-fonts/types";
+import type { Options as IconsOptions } from "unplugin-icons/types";
+import type { PluginOption } from "vite";
 
 import defaultTheme from "../default-theme/index.js";
 import { solidBaseMdx } from "./mdx.js";
@@ -25,6 +28,12 @@ export type SolidBaseConfig<ThemeConfig> = {
 		remarkPlugins?: PluggableList;
 		rehypePlugins?: PluggableList;
 	};
+	// enabled by default
+	fonts?: FontsOptions | false;
+	icons?: Omit<IconsOptions, "compiler"> | false;
+	// disabled by default
+	autoImport?:
+		| (AutoImportOptions & { iconResolver?: ComponentResolverOption | false }) | true;
 };
 
 type ResolvedConfigKeys =
@@ -50,7 +59,8 @@ export type LocaleConfig<ThemeConfig> = {
 export type ThemeDefinition<Config> = {
 	componentsPath: string;
 	extends?: ThemeDefinition<Config>;
-	vite?(config: SolidBaseResolvedConfig<Config>): PluginOption;
+	config?(config: SolidBaseResolvedConfig<Config>): void;
+	vite?(config: SolidBaseResolvedConfig<Config>): PluginOption | undefined;
 };
 
 export const withSolidBase = createWithSolidBase(defaultTheme);
@@ -88,6 +98,12 @@ export function createWithSolidBase<ThemeConfig>(
 			...solidBaseConfig,
 		};
 
+		let t: ThemeDefinition<any> | undefined = theme;
+		while (t !== undefined) {
+			if (t.config) t.config(sbConfig);
+			t = t.extends;
+		}
+
 		const vite = config.vite;
 
 		config.vite = (options) => {
@@ -100,7 +116,7 @@ export function createWithSolidBase<ThemeConfig>(
 
 			viteConfig.plugins = [...(viteConfig.plugins ?? [])];
 			viteConfig.plugins.push(solidBaseMdx(sbConfig));
-			viteConfig.plugins.push(solidBaseVitePlugin(theme, config, sbConfig));
+			viteConfig.plugins.push(solidBaseVitePlugin(theme, sbConfig));
 
 			let t: ThemeDefinition<any> | undefined = theme;
 			const plugins: Array<PluginOption> = [];
@@ -126,6 +142,7 @@ export function createWithSolidBase<ThemeConfig>(
 import { dirname, parse } from "node:path";
 import type { RehypeExpressiveCodeOptions } from "rehype-expressive-code";
 import type { PluggableList } from "unified";
+import type { ComponentResolverOption } from "unplugin-icons/resolver.js";
 import type { IssueAutoLinkConfig, TOCOptions } from "./remark-plugins";
 export function defineTheme<C>(def: ThemeDefinition<C>) {
 	return def;

--- a/src/config/vite-plugin/index.ts
+++ b/src/config/vite-plugin/index.ts
@@ -1,6 +1,10 @@
-import type { SolidStartInlineConfig } from "@solidjs/start/config";
+import AutoImport from "unplugin-auto-import/vite";
+import Unfonts from "unplugin-fonts/vite";
+import IconsResolver from "unplugin-icons/resolver";
+import Icons from "unplugin-icons/vite";
 import type { PluginOption } from "vite";
 
+import { fileURLToPath } from "node:url";
 import type { SolidBaseConfig, ThemeDefinition } from "../index.js";
 import {
 	componentsModule,
@@ -10,16 +14,16 @@ import {
 
 export default function solidBaseVitePlugin(
 	theme: ThemeDefinition<any>,
-	startConfig: SolidStartInlineConfig,
 	solidBaseConfig: Partial<SolidBaseConfig<any>>,
 ): PluginOption {
-	return [
+	const plugins: PluginOption[] = [
 		{
 			name: "solidbase:pre",
 			enforce: "pre",
 			resolveId(id) {
 				if (id === configModule.id) return configModule.resolvedId;
 				if (id === componentsModule.id) return componentsModule.resolvedId;
+				if (id.startsWith("\0unfonts.css")) return id.slice("\0".length);
 			},
 			async load(id) {
 				if (id === configModule.resolvedId)
@@ -45,8 +49,74 @@ export default function solidBaseVitePlugin(
 			},
 		},
 	];
+
+	if (solidBaseConfig.fonts !== false)
+		plugins.push(Unfonts(solidBaseConfig?.fonts));
+
+	if (solidBaseConfig.autoImport) {
+		const {
+			resolvers: _resolvers,
+			iconResolver,
+			...autoImport
+		} = solidBaseConfig.autoImport === true ? {} : solidBaseConfig.autoImport;
+
+		const resolvers: Resolver[] = [];
+
+		if (_resolvers) {
+			if (Array.isArray(_resolvers)) resolvers.push(..._resolvers.flat());
+			else resolvers.push(_resolvers);
+		}
+
+		if (iconResolver !== false)
+			resolvers.push(
+				IconsResolver({
+					prefix: "Icon",
+					...iconResolver,
+					extension: "jsx",
+				}),
+			);
+
+		plugins.push(
+			VinxiAutoImport({
+				dts: fileURLToPath(new URL("./src/auto-imports.d.ts", import.meta.url)),
+				...autoImport,
+				resolvers,
+			}),
+		);
+	}
+
+	if (solidBaseConfig.icons !== false)
+		plugins.push(
+			Icons({
+				compiler: "solid",
+				...solidBaseConfig.icons,
+			}),
+		);
+
+	return plugins;
 }
 
 export function isMarkdown(path: string) {
 	return !!path.match(/\.(mdx|md)/gm);
+}
+
+// Workaround for https://github.com/solidjs/solid-start/issues/1374
+import type { Options, Resolver } from "unplugin-auto-import/dist/types.js";
+function VinxiAutoImport(options: Options): PluginOption {
+	const autoimport = AutoImport(options);
+
+	const ABSOLUTE_PATH = /^\/|^[a-zA-Z]:\//;
+
+	return {
+		...autoimport,
+		transform(src, id) {
+			let pathname = id;
+
+			if (ABSOLUTE_PATH.test(id)) {
+				pathname = new URL(`file://${id}`).pathname;
+			}
+
+			return autoimport.transform(src, pathname);
+		},
+	};
 }

--- a/src/default-theme/index.ts
+++ b/src/default-theme/index.ts
@@ -16,18 +16,9 @@ export type DefaultThemeConfig = {
 
 const defaultTheme: ThemeDefinition<DefaultThemeConfig> = defineTheme({
 	componentsPath: import.meta.resolve("@kobalte/solidbase/default-theme"),
-	vite(config) {
-		return [
-			{
-				name: "solidbase-unfonts-workaround",
-				enforce: "pre",
-				resolveId(id) {
-					if (id.startsWith("\0unfonts.css")) {
-						return id.slice("\0".length);
-					}
-				},
-			},
-			Unfonts({
+	config(config) {
+		if (config.fonts === undefined)
+			config.fonts = {
 				fontsource: {
 					families: [
 						"Inter Variable",
@@ -35,9 +26,7 @@ const defaultTheme: ThemeDefinition<DefaultThemeConfig> = defineTheme({
 						"JetBrains Mono Variable",
 					],
 				},
-				...config?.themeConfig?.unfonts,
-			}),
-		];
+			};
 	},
 });
 export default defaultTheme;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     "declaration": true,
     "sourceMap": true,
     "lib": ["dom", "esnext"],
-    "types": ["solid-js", "vite", "vinxi/types/client", "vite/client"],
+    "types": ["solid-js", "vite", "vinxi/types/client", "vite/client", "unplugin-icons/types/solid"],
     "outDir": "./dist"
   },
   "include": ["src/**/*"],


### PR DESCRIPTION
adds [unplugin-icons](https://github.com/unplugin/unplugin-icons) and [unplugin-fonts](https://github.com/cssninjaStudio/unplugin-fonts) (enabled by default) to core, along with [unplugin-auto-import](https://github.com/unplugin/unplugin-auto-import) (disabled by default)