### PR TITLE
feat: custom tsconfig

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -5,7 +5,8 @@
 			"./tsconfig.json",
 			"*/netlify/*",
 			"**/package.json",
-			"./examples/solid-docs"
+			"./examples/solid-docs",
+			"**/app.config.*.js"
 		]
 	},
 	"vcs": {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,23 +1,17 @@
+import { dirname, parse } from "node:path";
 import type {
 	SolidStartInlineConfig,
 	ViteCustomizableConfig,
 } from "@solidjs/start/config";
 import type { Options as AutoImportOptions } from "unplugin-auto-import/dist/types.js";
 import type { Options as FontsOptions } from "unplugin-fonts/types";
+import type { ComponentResolverOption } from "unplugin-icons/resolver.js";
 import type { Options as IconsOptions } from "unplugin-icons/types";
 import type { PluginOption } from "vite";
 
-import { dirname, parse } from "node:path";
-import type { PluginTwoslashOptions } from "expressive-code-twoslash";
-import type { RehypeExpressiveCodeOptions } from "rehype-expressive-code";
-import type { PluggableList } from "unified";
-import type { ComponentResolverOption } from "unplugin-icons/resolver.js";
-import type { IssueAutoLinkConfig } from "./remark-plugins/issue-autolink.js";
-import type { PackageManagerConfig } from "./remark-plugins/package-manager-tabs.js";
-import type { TOCOptions } from "./remark-plugins/toc.js";
-
 import defaultTheme from "../default-theme/index.js";
-import { solidBaseMdx } from "./mdx.js";
+import { type MdxOptions, solidBaseMdx } from "./mdx.js";
+import type { IssueAutoLinkConfig } from "./remark-plugins/issue-autolink.js";
 import solidBaseVitePlugin from "./vite-plugin/index.js";
 
 export interface SolidBaseConfig<ThemeConfig> {
@@ -31,17 +25,7 @@ export interface SolidBaseConfig<ThemeConfig> {
 	themeConfig?: ThemeConfig;
 	editPath?: string | ((path: string) => string);
 	lastUpdated?: Intl.DateTimeFormatOptions | false;
-	markdown?: {
-		expressiveCode?:
-			| (RehypeExpressiveCodeOptions & {
-					twoSlash?: PluginTwoslashOptions | false;
-			  })
-			| false;
-		toc?: TOCOptions | false;
-		remarkPlugins?: PluggableList;
-		rehypePlugins?: PluggableList;
-		packageManagers?: PackageManagerConfig | false;
-	};
+	markdown?: MdxOptions;
 	// enabled by default
 	fonts?: FontsOptions | false;
 	icons?: Omit<IconsOptions, "compiler"> | false;

--- a/src/config/mdx.ts
+++ b/src/config/mdx.ts
@@ -3,12 +3,13 @@ import { pluginLineNumbers } from "@expressive-code/plugin-line-numbers";
 import { nodeTypes } from "@mdx-js/mdx";
 // @ts-expect-error
 import mdx from "@vinxi/plugin-mdx";
+import type { PluginTwoslashOptions } from "expressive-code-twoslash";
 import ecTwoSlash from "expressive-code-twoslash";
 import rehypeAutoLinkHeadings from "rehype-autolink-headings";
 import rehypeExpressiveCode, {
-	type RehypeExpressiveCodeOptions,
-	type ExpressiveCodeTheme,
 	type ExpressiveCodePlugin,
+	type ExpressiveCodeTheme,
+	type RehypeExpressiveCodeOptions,
 } from "rehype-expressive-code";
 import rehypeRaw from "rehype-raw";
 import rehypeSlug from "rehype-slug";
@@ -17,6 +18,7 @@ import remarkFrontmatter from "remark-frontmatter";
 import remarkGfm from "remark-gfm";
 import remarkMdxFrontmatter from "remark-mdx-frontmatter";
 import { convertCompilerOptionsFromJson } from "typescript";
+import type { PluggableList } from "unified";
 
 import type { SolidBaseResolvedConfig } from "./index.js";
 import { rehypeFixExpressiveCodeJsx } from "./rehype-plugins/fix-expressive-code.js";
@@ -25,10 +27,24 @@ import { remarkDirectiveContainers } from "./remark-plugins/directives.js";
 import { remarkGithubAlertsToDirectives } from "./remark-plugins/gh-directives.js";
 import { remarkIssueAutolink } from "./remark-plugins/issue-autolink.js";
 import { remarkAddClass } from "./remark-plugins/kbd.js";
+import type { PackageManagerConfig } from "./remark-plugins/package-manager-tabs.js";
 import { remarkPackageManagerTabs } from "./remark-plugins/package-manager-tabs.js";
 import { remarkRelativeImports } from "./remark-plugins/relative-imports.js";
 import { remarkTabGroup } from "./remark-plugins/tab-group.js";
+import type { TOCOptions } from "./remark-plugins/toc.js";
 import { remarkTOC } from "./remark-plugins/toc.js";
+
+export interface MdxOptions {
+	expressiveCode?:
+		| (RehypeExpressiveCodeOptions & {
+				twoSlash?: (PluginTwoslashOptions & { tsconfig: any }) | false;
+		  })
+		| false;
+	toc?: TOCOptions | false;
+	remarkPlugins?: PluggableList;
+	rehypePlugins?: PluggableList;
+	packageManagers?: PackageManagerConfig | false;
+}
 
 export function solidBaseMdx(sbConfig: SolidBaseResolvedConfig<any>) {
 	return mdx.default.withImports({})({
@@ -63,6 +79,7 @@ function getRehypePlugins(sbConfig: SolidBaseResolvedConfig<any>) {
 								lib: ["dom", "esnext"],
 								jsxImportSource: "solid-js",
 								jsx: "preserve",
+								...sbConfig.markdown?.expressiveCode?.twoSlash?.tsconfig,
 							},
 							".",
 						).options,

--- a/src/config/mdx.ts
+++ b/src/config/mdx.ts
@@ -70,19 +70,24 @@ function getRehypePlugins(sbConfig: SolidBaseResolvedConfig<any>) {
 			plugins.push(
 				ecTwoSlash({
 					twoslashOptions: {
-						compilerOptions: convertCompilerOptionsFromJson(
-							{
-								allowSyntheticDefaultImports: true,
-								esModuleInterop: true,
-								target: "ESNext",
-								module: "ESNext",
-								lib: ["dom", "esnext"],
-								jsxImportSource: "solid-js",
-								jsx: "preserve",
-								...sbConfig.markdown?.expressiveCode?.twoSlash?.tsconfig,
-							},
-							".",
-						).options,
+						compilerOptions: {
+							...convertCompilerOptionsFromJson(
+								{
+									allowSyntheticDefaultImports: true,
+									esModuleInterop: true,
+									target: "ESNext",
+									module: "ESNext",
+									lib: ["dom", "esnext"],
+									jsxImportSource: "solid-js",
+									jsx: "preserve",
+									...sbConfig.markdown?.expressiveCode?.twoSlash?.tsconfig,
+								},
+								".",
+							).options,
+							...sbConfig.markdown?.expressiveCode?.twoSlash?.twoslashOptions
+								?.compilerOptions,
+						},
+						...sbConfig.markdown?.expressiveCode?.twoSlash?.twoslashOptions,
 					},
 					...sbConfig.markdown?.expressiveCode?.twoSlash,
 				}),


### PR DESCRIPTION
adds `.markdown.expressiveCode.twoSlash.tsconfig` to allow customising the tsconfig used by twoslash using the `tsconfig.json` syntax, rather than typescript's internal format.
`.markdown.expressiveCode.twoSlash.twoslashOptions.compilerOptions` will still override the tsconfig