### PR TITLE
fix: reexport solid-mdx from @kobalte/solidbase/solid-mdx

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,6 @@
     "@solidjs/start": "^1.1.1",
     "@vinxi/plugin-mdx": "^3.7.2",
     "solid-js": "^1.9.5",
-    "solid-mdx": "^0.0.7",
     "vinxi": "^0.5.3"
   },
   "engines": {

--- a/src/config/mdx.ts
+++ b/src/config/mdx.ts
@@ -50,7 +50,7 @@ export function solidBaseMdx(sbConfig: SolidBaseResolvedConfig<any>) {
 	return mdx.default.withImports({})({
 		jsx: true,
 		jsxImportSource: "solid-js",
-		providerImportSource: "solid-mdx",
+		providerImportSource: "@kobalte/solidbase/solid-mdx",
 		stylePropertyNameCase: "css",
 		rehypePlugins: getRehypePlugins(sbConfig),
 		remarkPlugins: getRemarkPlugins(sbConfig),

--- a/src/solid-mdx.ts
+++ b/src/solid-mdx.ts
@@ -1,0 +1,1 @@
+export * from "solid-mdx";


### PR DESCRIPTION
`@kobalte/solidbase/solid-mdx` now re-exports `solid-mdx`, so `solid-mdx` no longer needs to be hoisted when using pnpm.