### PR TITLE
fix: remove RouteSectionProps

### DIFF
--- a/dev/src/solidbase-theme/Layout.tsx
+++ b/dev/src/solidbase-theme/Layout.tsx
@@ -1,13 +1,13 @@
 import { Title } from "@solidjs/meta";
-import type { RouteSectionProps } from "@solidjs/router";
 
 import Layout from "@kobalte/solidbase/default-theme/Layout.jsx";
+import type { ParentProps } from "solid-js";
 
-export default function (props: RouteSectionProps) {
+export default function (props: ParentProps) {
 	return (
 		<>
 			<Title>I am the captain now</Title>
-			<Layout {...props} />
+			<Layout>{props.children}</Layout>
 		</>
 	);
 }

--- a/docs/src/routes/guide/(customization)/custom-themes.mdx
+++ b/docs/src/routes/guide/(customization)/custom-themes.mdx
@@ -68,9 +68,9 @@ SolidBase's default theme uses its own Vite plugin to
 The most basic `Layout` receives the current route as `children` and renders it:
 
 ```tsx
-import { type RouteSectionProps } from "@solidjs/router";
+import { ParentProps } from "solid-js";
 
-export default function Layout(props: RouteSectionProps) {
+export default function Layout(props: ParentProps) {
   return <>{props.children}</>;
 }
 ```

--- a/src/client/Root.tsx
+++ b/src/client/Root.tsx
@@ -1,21 +1,18 @@
 import { Layout, mdxComponents } from "virtual:solidbase/components";
 import { Meta, MetaProvider, Title } from "@solidjs/meta";
-import type { RouteSectionProps } from "@solidjs/router";
 import { Suspense, createMemo, onMount } from "solid-js";
 import { MDXProvider } from "solid-mdx";
 
 import { useRouteSolidBaseConfig } from "./config";
 import { SolidBaseContext } from "./context";
 
-export function SolidBaseRoot(
-	props: RouteSectionProps & {
-		currentPageData?: { deferStream?: boolean };
-		meta?: {
-			// allows diabling MetaProvider for cases where you've already got one
-			provider?: boolean;
-		};
-	},
-) {
+export function SolidBaseRoot(props: {
+	currentPageData?: { deferStream?: boolean };
+	meta?: {
+		// allows diabling MetaProvider for cases where you've already got one
+		provider?: boolean;
+	};
+}) {
 	onMount(() => {
 		const { $$SolidBase } = window as {
 			$$SolidBase?: { initTwoslashPopups?(): void };
@@ -28,7 +25,7 @@ export function SolidBaseRoot(
 			<LocaleContextProvider>
 				<CurrentPageDataProvider {...props.currentPageData}>
 					<MDXProvider components={mdxComponents}>
-						<Inner {...props} />
+						<Inner />
 					</MDXProvider>
 				</CurrentPageDataProvider>
 			</LocaleContextProvider>
@@ -48,7 +45,7 @@ export function SolidBaseRoot(
 import { LocaleContextProvider } from "./locale";
 import { CurrentPageDataProvider, useCurrentPageData } from "./page-data";
 
-export function Inner(props: RouteSectionProps) {
+export function Inner() {
 	const config = useRouteSolidBaseConfig();
 	const pageData = useCurrentPageData();
 
@@ -75,7 +72,7 @@ export function Inner(props: RouteSectionProps) {
 		<SolidBaseContext.Provider value={{ config, metaTitle }}>
 			<Title>{metaTitle()}</Title>
 			{description() && <Meta name="description" content={description()} />}
-			<Layout {...props} />
+			<Layout />
 		</SolidBaseContext.Provider>
 	);
 }

--- a/src/default-theme/Layout.tsx
+++ b/src/default-theme/Layout.tsx
@@ -1,8 +1,8 @@
 // @refresh reload
 import { Dialog } from "@kobalte/core/dialog";
 import { Title } from "@solidjs/meta";
-import { A, type RouteSectionProps } from "@solidjs/router";
-import { For, Show } from "solid-js";
+import { A } from "@solidjs/router";
+import { For, type ParentProps, Show } from "solid-js";
 
 import type { Sidebar, SidebarLink } from ".";
 import { useLocale, useThemeListener } from "../client";
@@ -21,15 +21,15 @@ import styles from "./Layout.module.css";
 import "./index.css";
 import { usePace } from "./pace";
 
-export default (props: RouteSectionProps) => (
+export default (props: ParentProps) => (
 	<DefaultThemeStateProvider>
 		<DefaultThemeComponentsProvider>
-			<Layout {...props} />
+			<Layout>{props.children}</Layout>
 		</DefaultThemeComponentsProvider>
 	</DefaultThemeStateProvider>
 );
 
-function Layout(props: RouteSectionProps) {
+function Layout(props: ParentProps) {
 	const { Header, Article, Link } = useDefaultThemeComponents();
 	const { sidebarOpen, setSidebarOpen, frontmatter } = useDefaultThemeState();
 	const config = useRouteConfig();

--- a/src/virtual.d.ts
+++ b/src/virtual.d.ts
@@ -3,9 +3,7 @@ declare module "virtual:solidbase/config" {
 }
 
 declare module "virtual:solidbase/components" {
-	export const Layout: import("solid-js").Component<
-		import("@solidjs/router").RouteSectionProps
-	>;
+	export const Layout: import("solid-js").Component;
 	export const mdxComponents: Record<string, import("solid-js").Component<any>>;
 }
 


### PR DESCRIPTION
everything in RouteSectionProps can be accessed via hooks, only children needs to be passed down