### PR TITLE
Fix build on windows

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -3,8 +3,8 @@
   "type": "module",
   "private": "true",
   "scripts": {
-    "dev": "NODE_OPTIONS=\"--max-old-space-size=8192\" VITE_SOLIDBASE_DEV=true vinxi dev",
-    "build": "NODE_OPTIONS=\"--max-old-space-size=8192\" vinxi build",
+    "dev": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" VITE_SOLIDBASE_DEV=true vinxi dev",
+    "build": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" vinxi build",
     "start": "vinxi start"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "@types/mdast": "^4.0.4",
     "@types/resolve": "^1.20.6",
     "@types/unist": "^3.0.3",
+    "cross-env": "^7.0.3",
     "esbuild": "^0.25.2",
     "glob": "^11.0.1",
     "mdast": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       '@types/unist':
         specifier: ^3.0.3
         version: 3.0.3
+      cross-env:
+        specifier: ^7.0.3
+        version: 7.0.3
       esbuild:
         specifier: ^0.25.2
         version: 0.25.2
@@ -2204,6 +2207,11 @@ packages:
   croner@9.0.0:
     resolution: {integrity: sha512-onMB0OkDjkXunhdW9htFjEhqrD54+M94i6ackoUkjHKbRnXdyEyKRelp4nJ1kAz32+s27jP1FsebpJCVl0BsvA==}
     engines: {node: '>=18.0'}
+
+  cross-env@7.0.3:
+    resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
+    engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -6577,6 +6585,10 @@ snapshots:
       readable-stream: 4.7.0
 
   croner@9.0.0: {}
+
+  cross-env@7.0.3:
+    dependencies:
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:

--- a/src/default-theme/index.ts
+++ b/src/default-theme/index.ts
@@ -6,8 +6,8 @@ import type { SidebarConfig } from "../config/sidebar.js";
 export type DefaultThemeConfig = {
 	footer?: boolean;
 	socialLinks?:
-		| Record<Exclude<SocialLink["type"], "custom">, string>
-		| Record<string, Omit<SocialLink, "type">>;
+	| Record<Exclude<SocialLink["type"], "custom">, string>
+	| Record<string, Omit<SocialLink, "type">>;
 	nav?: Array<NavItem>;
 	sidebar?: SidebarConfig;
 	search?: SearchConfig;
@@ -65,14 +65,14 @@ const defaultTheme: ThemeDefinition<DefaultThemeConfig> = defineTheme({
 				load(id) {
 					if (id.startsWith("virtual:solidbase/default-theme/fonts.css"))
 						return filteredFonts
-							.map((font) => `@import url(${fileURLToPath(font.cssPath)});`)
+							.map((font) => `@import url(${fileURLToPath(font.cssPath, { windows: false })});`)
 							.join("\n");
 					if (id.startsWith("\0virtual:solidbase/default-theme/fonts")) {
 						const preloadFonts = filteredFonts.map((font, i) => {
 							const pathIdent = `font_${i}`;
 							return {
 								pathIdent,
-								import: `import ${pathIdent} from "${fileURLToPath(font.preloadFontPath)}?url";`,
+								import: `import ${pathIdent} from "${fileURLToPath(font.preloadFontPath, { windows: false })}?url";`,
 								type: font.fontType,
 							};
 						});
@@ -82,8 +82,8 @@ const defaultTheme: ThemeDefinition<DefaultThemeConfig> = defineTheme({
 
 							export const preloadFonts = [
 								${preloadFonts
-									.map((f) => `{ path: ${f.pathIdent}, type: "${f.type}" }`)
-									.join(",")}
+								.map((f) => `{ path: ${f.pathIdent}, type: "${f.type}" }`)
+								.join(",")}
 							];
 						`;
 					}


### PR DESCRIPTION
- Generate correct paths to fonts (without backslashes)
- Add [cross-env](https://www.npmjs.com/package/cross-env) for cross-platform environment variable handling