### PR TITLE
Fix TOC titles when the title has inline code

### DIFF
--- a/dev/src/routes/index.mdx
+++ b/dev/src/routes/index.mdx
@@ -6,6 +6,8 @@ title: Test2
 
 ## Heading 2
 
+## Heading 2 with `code`
+
 ### Heading 3
 
 #### Heading 4

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "hastscript": "^9.0.0",
     "mdast-util-find-and-replace": "^3.0.1",
     "mdast-util-mdx-jsx": "^3.2.0",
+    "mdast-util-to-string": "^4.0.0",
     "mdast-util-toc": "^7.1.0",
     "rehype-autolink-headings": "^7.1.0",
     "rehype-expressive-code": "^0.40.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       mdast-util-mdx-jsx:
         specifier: ^3.2.0
         version: 3.2.0
+      mdast-util-to-string:
+        specifier: ^4.0.0
+        version: 4.0.0
       mdast-util-toc:
         specifier: ^7.1.0
         version: 7.1.0

--- a/src/config/remark-plugins/toc.ts
+++ b/src/config/remark-plugins/toc.ts
@@ -2,6 +2,7 @@ import { fromJs } from "esast-util-from-js";
 import type { PhrasingContent } from "mdast";
 import { findAndReplace } from "mdast-util-find-and-replace";
 import { type Options, toc } from "mdast-util-toc";
+import { toString } from "mdast-util-to-string"
 
 interface ParagraphNode {
 	type: "paragraph";
@@ -31,7 +32,7 @@ interface TOCTree {
 
 function mapNode(node: ListItemNode): TOCTree {
 	return {
-		title: node.children[0].children[0].children[0].value,
+		title: toString(node.children[0].children[0].children),
 		href: node.children[0].children[0].url,
 		children: (node.children[1]?.children ?? []).map(mapNode),
 	};


### PR DESCRIPTION
When a heading contains inline code, the TOC only displays the title up to the start of the code.

<img width="990" height="153" alt="image" src="https://github.com/user-attachments/assets/7cadd71c-85ec-42bc-8f83-2ce96124541c" />

This issue occurs because only the first child of the heading node is included in the `title` property. This PR fixes that.

@jer3m01 @Brendonovich I'd appreciate it if you could release this soon. It's a significant issue in the Solid docs.