### PR TITLE
fix: change top-logo link from root path to base path.

### DIFF
--- a/src/default-theme/Layout.tsx
+++ b/src/default-theme/Layout.tsx
@@ -107,7 +107,7 @@ function Layout(props: ParentProps) {
 									<Dialog.Content class={styles.sidenav}>
 										<div class={styles["sidenav-content"]}>
 											<div class={styles["sidenav-header"]}>
-												<a href="/" class={styles["logo-link"]}>
+												<a href={config().base || "/"} class={styles["logo-link"]}>
 													<Show
 														when={config().logo}
 														fallback={<span>{config().title}</span>}


### PR DESCRIPTION
Hi, Thank you for managing good project. 

I am making mdx site generator with solidbase. For the case of who dont use root path url for the website, I need to change this. The idea is manage md/mdx document three and build automatically. The project is [here](https://github.com/nikescar/mdx-sitegen-solidbase). 

Because github pages are static server, SPA like solidjs does not work well. I found github 404 page has intact url with the page. so I could make redirection script to 404 page. the first page with redirection may seems bumpy. but it works for any browser and some search engine.